### PR TITLE
Skip devices without resolved type

### DIFF
--- a/sync_devices.py
+++ b/sync_devices.py
@@ -34,6 +34,10 @@ def sync_devices():
         nm = d.get("hostname") or d.get("sysName")
         vendor, model = resolve_device_type(d)
         dtid = import_device_type_if_exists(vendor, model)
+        if dtid is None:
+            print(f"SKIP sin device_type {nm} ({vendor}/{model})")
+            continue
+
         cf = {"cf_librenms_id": lid}
         existe = nb_get("dcim/devices/", **cf).get("count", 0)
         if existe:
@@ -49,6 +53,5 @@ def sync_devices():
         }
         nb_post("dcim/devices/", pl)
         print(f"+ Creado {nm} ({lid}) con device_type {dtid}")
-
-if __name__=="__main__":
+if __name__ == "__main__":
     sync_devices()


### PR DESCRIPTION
## Summary
- evitar enviar devices sin `device_type` a NetBox

## Testing
- `python -m py_compile sync_devices.py main.py`
- `venv/bin/python main.py` *(falla: Invalid URL 'None/api/v0/devices?limit=0')*

------
https://chatgpt.com/codex/tasks/task_b_689346a0ee58832cb2107c852e42b534