### PR TITLE
Handle existing manufacturer gracefully

### DIFF
--- a/api_netbox.py
+++ b/api_netbox.py
@@ -31,12 +31,19 @@ def nb_post(endpoint, payload):
     return resp.json()
 
 def get_or_create_manufacturer_id(slug: str):
+    slug = (slug or "").strip().lower()
     resp = nb_get("dcim/manufacturers/", slug=slug)
     if resp.get("count", 0):
         return resp["results"][0]["id"]
     data = {"name": slug.capitalize(), "slug": slug}
-    created = nb_post("dcim/manufacturers/", data)
-    return created.get("id")
+    try:
+        created = nb_post("dcim/manufacturers/", data)
+        return created.get("id")
+    except requests.HTTPError:
+        resp = nb_get("dcim/manufacturers/", slug=slug)
+        if resp.get("count", 0):
+            return resp["results"][0]["id"]
+        raise
 
 def get_device_type_id(vendor: str, fname: str):
     vendor = vendor.lower().strip()

--- a/device_type_importer.py
+++ b/device_type_importer.py
@@ -11,7 +11,7 @@ DRY = DRY_RUN
 
 def create_generic_device_type():
     """Crea un device-type genérico si no existe"""
-    man_id = get_or_create_manufacturer_id("Generic")
+    man_id = get_or_create_manufacturer_id("generic")
     
     # Verificar si ya existe
     check = nb_get(


### PR DESCRIPTION
## Summary
- normalize manufacturer slugs before NetBox lookup
- fall back to existing manufacturer when creation returns an error
- ensure generic device type uses lowercase manufacturer slug

## Testing
- `python -m py_compile api_netbox.py device_type_importer.py device_utils.py`


------
https://chatgpt.com/codex/tasks/task_b_68936b335224832ca6113da354aafcbd