### PR TITLE
Add LibreNMS port sync

### DIFF
--- a/api_librenms.py
+++ b/api_librenms.py
@@ -1,9 +1,19 @@
 import requests
 from config import LIBRENMS_URL, LIBRENMS_TOKEN
 
+
 def get_librenms_devices():
     headers = {"X-Auth-Token": LIBRENMS_TOKEN}
     url = f"{LIBRENMS_URL}/api/v0/devices?limit=0"
     resp = requests.get(url, headers=headers, timeout=60)
     resp.raise_for_status()
     return resp.json().get("devices", [])
+
+
+def get_librenms_device_ports(device_id):
+    headers = {"X-Auth-Token": LIBRENMS_TOKEN}
+    url = f"{LIBRENMS_URL}/api/v0/devices/{device_id}/ports?limit=0"
+    resp = requests.get(url, headers=headers, timeout=60)
+    resp.raise_for_status()
+    return resp.json().get("ports", [])
+


### PR DESCRIPTION
## Summary
- add helper to fetch ports for a LibreNMS device
- sync device interfaces from LibreNMS to NetBox, skipping existing ones

## Testing
- `python -m py_compile api_librenms.py sync_devices.py`


------
https://chatgpt.com/codex/tasks/task_b_689378c0bb4c832ca15bad8385df0b39