### PR TITLE
Add NetBox payload fields and custom LibreNMS data

### DIFF
--- a/sync_devices.py
+++ b/sync_devices.py
@@ -4,6 +4,16 @@ from device_type_importer import import_device_type_if_exists
 from device_utils import resolve_device_type, validate_device
 from config import DEFAULT_SITE_SLUG, DEFAULT_ROLE_SLUG
 
+
+def get_platform_id(slug: str | None) -> int | None:
+    """Return NetBox platform ID for given slug if it exists."""
+    if not slug:
+        return None
+    resp = nb_get("dcim/platforms/", slug=slug)
+    if resp.get("count"):
+        return resp["results"][0]["id"]
+    return None
+
 def get_site_id(slug):
     resp = nb_get("dcim/sites/", slug=slug)
     if resp.get("count"):
@@ -34,10 +44,7 @@ def sync_devices():
         vendor, model = resolve_device_type(d)
         dtid = import_device_type_if_exists(vendor, model)
         if dtid is None:
-
             print(f"SKIP {nm}: Sin device_type válido (vendor={vendor} model={model})")
-            continue
-            print(f"SKIP sin device_type {nm} ({vendor}/{model})")
             continue
 
         cf = {"cf_librenms_id": lid}
@@ -53,6 +60,31 @@ def sync_devices():
             "status": "active",
             "custom_fields": {"librenms_id": str(lid)},
         }
+
+        if d.get("serial"):
+            pl["serial"] = d["serial"]
+        if d.get("asset_tag"):
+            pl["asset_tag"] = d["asset_tag"]
+        if d.get("os"):
+            plat_id = get_platform_id(d.get("os"))
+            if plat_id:
+                pl["platform"] = plat_id
+        ip4 = d.get("ip") or d.get("ipv4") or d.get("ip4") or d.get("primary_ip")
+        if ip4:
+            pl["primary_ip4"] = ip4
+        if d.get("notes"):
+            pl["comments"] = d["notes"]
+
+        extra_cf_map = {
+            "hardware": "librenms_hardware",
+            "location": "librenms_location",
+            "purpose": "librenms_purpose",
+        }
+        for key, cf_name in extra_cf_map.items():
+            val = d.get(key)
+            if val:
+                pl.setdefault("custom_fields", {})[cf_name] = str(val)
+
         nb_post("dcim/devices/", pl)
         print(f"+ Creado {nm} ({lid}) con device_type {dtid}")
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend NetBox device payload to include serial, asset tag, platform, primary IPv4 and comments
- propagate extra LibreNMS fields (hardware/location/purpose) into custom fields

## Testing
- `python -m py_compile sync_devices.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689378e097b8832cab4de11cb22fe4da